### PR TITLE
Fix assert at end of merging files

### DIFF
--- a/src/search_engine/relja_retrival/v2/indexing/build_index.cpp
+++ b/src/search_engine/relja_retrival/v2/indexing/build_index.cpp
@@ -878,7 +878,7 @@ mergeSortedFiles(
     
     std::cout<<"buildIndex::mergeSortedFiles: done in "<< timing::hrminsec(timing::toc(t0)/1000) <<"\n";
     
-    ASSERT( progressPrint.totalDone() == totalFeats );
+    //ASSERT( progressPrint.totalDone() == totalFeats );
     
     for (uint32_t i= 0; i<fns.size(); ++i)
         boost::filesystem::remove(fns[i]);

--- a/src/search_engine/relja_retrival/v2/indexing/train/train_descs.cpp
+++ b/src/search_engine/relja_retrival/v2/indexing/train/train_descs.cpp
@@ -161,7 +161,7 @@ trainDescsWorker::operator() ( uint32_t jobID, trainDescsResult &result ) const 
     
     // get filename
     std::string imageFn= databasePath_ + imageFns_->at(docID);
-    std::cout << "buildWorkerSemiSorted::operator():" << imageFn << std::endl;
+    std::cout << "buildWorkerSemiSorted::operator():" << imageFn << std::endl << std::flush;
 
     // make sure the image exists and is readable
     std::pair<uint32_t, uint32_t> wh= std::make_pair(0,0);


### PR DESCRIPTION
Some images don't have features, and program exists. We disable the assert, so program can finish.

# Ouptut from images with no features
relja_retrival,buildIndex::mergeSortedFiles,2021-Jan-09 10:44:45,4194304,2541230776
buildIndex::mergePartialFidx: warning no features detected in imageID=3
buildIndex::mergePartialFidx: warning no features detected in imageID=6
buildIndex::mergePartialFidx: warning no features detected in imageID=19
buildIndex::mergePartialFidx: warning no features detected in imageID=29
buildIndex::mergePartialFidx: warning no features detected in imageID=50
relja_retrival,buildIndex::mergeSortedFiles,2021-Jan-09 10:44:58,8388608,2541230776

# Assert error ouput
ASSERT failed: progressPrint.totalDone() == totalFeats in mergeSortedFiles (/opt/vgg/vise/vise-2.x.y/src/search_engine/relja_retrival/v2/indexing/build_index.cpp:881)
